### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
     - php: hhvm
       env: dependencies=highest
   allow_failures:
-    - php: 7
     - php: hhvm
 
 ## Update composer and run the appropriate composer command


### PR DESCRIPTION
Updating .travis.yml to stop allowing PHP 7 failures. 