### PR TITLE
Make Mime\Html->extract() title parsing a bit better

### DIFF
--- a/src/Mime/Html.php
+++ b/src/Mime/Html.php
@@ -41,7 +41,7 @@ class Html implements MimeInterface
      */
     public function extract(array $replacements, UrlInterface $url)
     {
-        if (preg_match('#<title[^>]*>(.*?)</title>#is', $url->getBody(), $match)) {
+        if (preg_match('#<title[^>]*>([^<]+)</title>#is', $url->getBody(), $match)) {
             $replacements['%composed-title%'] =
             $replacements['%title%'] =
             preg_replace('/[\s\v]+/', ' ', trim(html_entity_decode($match[1], ENT_QUOTES | ENT_HTML5)));

--- a/tests/Mime/HtmlTest.php
+++ b/tests/Mime/HtmlTest.php
@@ -61,6 +61,13 @@ class HtmlTest extends \PHPUnit_Framework_TestCase {
                 new Url('', '<html><title>foo&#39;s w&ouml;rk</title></html></html>', array(), 200, 1),
             ),
             array(
+                array(
+                    '%title%' => 'Avatar: The Last Airbender Is Returning as a New Netflix Series',
+                    '%composed-title%' => 'Avatar: The Last Airbender Is Returning as a New Netflix Series',
+                ),
+                new Url('', '<title>pq-earther<\/title><path /><title>Avatar: The Last Airbender Is Returning as a New Netflix Series</title>', array(), 200, 1),
+            ),
+            array(
                 array(),
                 new Url('', '', array(), 200, 1),
             ),


### PR DESCRIPTION
So, this happened...

```
16:09:56    pteague_work | think i found the story i just saw a screen shot of - https://io9.gizmodo.com/avatar-the-last-airbender-is-being-reborn-as-a-netflix-1829139229
16:09:58         Phergie | [https://u.gsc.io/1] storybreak stars<\/title><path d="M5.1469.01l-.19-3.623 3.057 1.985.693-1.197-3.213-1.673.213-1.638-.693-1.197-3.056 1.953L5.147 0H3.76l.158 3.623L.8931.67.2 2.867l3.214 1.638L.2 6.175l.693 1.197 3.025-1.985L3.769.01m21.386 0l-.19-3.623 3.057 1.985.693-1.197-3.213-1.673.213-1.638-.693-1.197-3.056 1.953.19-3.623H23.76l.1583.623-3.025-1.953-.693 1.197 3.214 1.638-3.214 1.67.693 1.1973.025-1.985-.158 3.623m21.386 0l-.19-3.623
16:10:09    pteague_work | um, wow Phergie ...
```